### PR TITLE
removed deprecated rumsan-ui package

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
 		"react-toast-notifications": "^2.4.0",
 		"reactstrap": "^8.4.1",
 		"redux-devtools-extension": "^2.13.8",
-		"rumsan-ui": "^1.0.11",
 		"sweetalert2": "^9.17.2",
 		"xlsx": "^0.17.0",
 		"yarn": "^1.22.4",


### PR DESCRIPTION
The instructions regarding installation of the project requires `yarn install`. However I was instructed to remove the deprecated  `rumsan-ui` package.

I removed it from `package.json`, however, this caused some different errors. See below.

Please advise what I should do? 

<img width="1650" alt="CleanShot 2022-10-19 at 04 48 56@2x" src="https://user-images.githubusercontent.com/71540402/196644339-d066cf55-663f-42a9-b506-d35199d1f957.png">
